### PR TITLE
41 flashbang not stunning players properly fixed

### DIFF
--- a/SFDScripts/Internal/Hardcore/Hardcore.cs
+++ b/SFDScripts/Internal/Hardcore/Hardcore.cs
@@ -65,22 +65,22 @@ namespace SFDScripts
         /// - Doesn't end the game when there isn't enough players
         /// - Shows some extra visual debugging info
         /// </remakrs>
-        public static bool IsDebug = true;
+        public static bool IsDebug = false;
 
         /// <summary>
         /// Defines wether we want to show the debug messages or not as logs in the chat
         /// </summary>
-        public static bool ShowDebugMessages = true;
+        public static bool ShowDebugMessages = false;
 
         /// <summary>
         // When true, we use a file called hardcoredebug.txt rather than hardcore.txt for loading and saving data
         /// </summary>
-        public static bool UseDebugStorage = true;
+        public static bool UseDebugStorage = false;
 
         /// <summary>
         /// When true, there's no need to set players to ready, they will all be ready from the start;
         /// </summary>
-        public static bool MakeAllPlayersReadyFromTheStart = true;
+        public static bool MakeAllPlayersReadyFromTheStart = false;
 
         #endregion
 

--- a/SFDScripts/Internal/Hardcore/Hardcore.cs
+++ b/SFDScripts/Internal/Hardcore/Hardcore.cs
@@ -370,7 +370,7 @@ namespace SFDScripts
                     Object = obj;
                 }
                 Position = Object.GetWorldPosition();
-                if (Id == 2 || Id == 3) FastReloading = 1000;
+                if (Id == 2 || Id == 3) FastReloading = 100;
                 if (Id == 2)
                 {
                     SmokeCount = 400;
@@ -384,9 +384,14 @@ namespace SFDScripts
                     GlobalGame.SpawnFireNodes(Position, 50, new Vector2(0, 0), 3, 10, FireNodeType.Flamethrower);
                 }
                 if (Id == 0 || Id == 1) ReadyForRemove = true;
-                if (Id == 2 || Id == 3)
+
+                if(Id == 3)
                 {
-                    System.Diagnostics.Debugger.Break();
+                    StunExplosion();
+                }
+
+                if (Id == 2)
+                {
                     Object = GlobalGame.CreateObject("DrinkingGlass00", Position);
                 }
             }
@@ -396,7 +401,7 @@ namespace SFDScripts
                 if (Object != null && !Object.RemovalInitiated && !Object.IsRemoved) Position = Object.GetWorldPosition();
                 else if (!IsDestroyed) OnDestroyed();
                 
-                if (IsDebug)
+                if (IsDebug && Id == 3)
                 {
                     DebugPlayersWhoAreBeingHitByFlash();
                 }
@@ -416,12 +421,6 @@ namespace SFDScripts
                 else if (Id == 3 && FastReloading == 0)
                 {
                     StunExplosion();
-                    GlobalGame.PlayEffect("EXP", Position);
-                    GlobalGame.PlayEffect("S_P", Position);
-                    GlobalGame.PlayEffect("S_P", Position);
-                    GlobalGame.PlaySound("Explosion", Position, 1);
-                    Object.Remove();
-                    ReadyForRemove = true;
                 }
             }
 
@@ -429,6 +428,22 @@ namespace SFDScripts
             private TPlayer _currentPlayerBeingTested;
 
             public void StunExplosion()
+            {
+                PlayExplosionVisualEffects();
+                GlobalGame.PlaySound("Explosion", Position, 1);
+                StunPlayersInRangeNotCoveredByWall();
+                Object.Remove();
+                ReadyForRemove = true;
+            }
+
+            private void PlayExplosionVisualEffects()
+            {
+                GlobalGame.PlayEffect("EXP", Position);
+                GlobalGame.PlayEffect("S_P", Position);
+                GlobalGame.PlayEffect("S_P", Position);
+            }
+
+            private void StunPlayersInRangeNotCoveredByWall()
             {
                 var position = Position + new Vector2(0, 10);
                 for (int i = 0; i < PlayerList.Count; i++)
@@ -441,12 +456,9 @@ namespace SFDScripts
                     if (dist > RangeForFlashbang) continue;
 
                     if (!IsPlayerBeingTestedHitByFlashbang()) continue;
-
-                    // if (TracePath(position, PlayerList[i].Position, PlayerTeam.Independent, true) <= 2)
                     _currentPlayerBeingTested.StunTime += (int)(DurationOfFlashbangStunTime * (1 - dist / RangeForFlashbang));
                 }
             }
-
 
             private void DebugPlayersWhoAreBeingHitByFlash()
             {
@@ -458,7 +470,6 @@ namespace SFDScripts
                     {
                         continue;
                     }
-
                     IsPlayerBeingTestedHitByFlashbang();
                 }
             }

--- a/SFDScripts/Internal/Hardcore/Hardcore.cs
+++ b/SFDScripts/Internal/Hardcore/Hardcore.cs
@@ -387,7 +387,7 @@ namespace SFDScripts
 
                 if(Id == 3)
                 {
-                    StunExplosion();
+                    FlashbangExplosion();
                 }
 
                 if (Id == 2)
@@ -421,7 +421,7 @@ namespace SFDScripts
 
                 if (Id == 3)
                 {
-                    StunExplosion();
+                    FlashbangExplosion();
                 }
             }
 
@@ -441,11 +441,13 @@ namespace SFDScripts
 
             private TPlayer _currentPlayerBeingTested;
 
-            public void StunExplosion()
+            public void FlashbangExplosion()
             {
                 PlayExplosionVisualEffects();
                 GlobalGame.PlaySound("Explosion", Position, 1);
+
                 StunPlayersInRangeNotCoveredByWall();
+                
                 ThrownWeaponObject.Remove();
                 ReadyForRemove = true;
             }
@@ -463,15 +465,20 @@ namespace SFDScripts
                 for (int i = 0; i < PlayerList.Count; i++)
                 {
                     _currentPlayerBeingTested = PlayerList[i];
-                    if (_currentPlayerBeingTested.User.GetPlayer() == null || _currentPlayerBeingTested.User.GetPlayer().IsDead) continue;
+                    if (IsCurrentPlayerBodyDeadOrNull()) continue;
 
-                    var dist = (_currentPlayerBeingTested.Position - position).Length();
-
-                    if (dist > RangeForFlashbang) continue;
+                    var distanceFromPlayerToFlashbang = (_currentPlayerBeingTested.Position - position).Length();
+                    if (distanceFromPlayerToFlashbang > RangeForFlashbang) continue;
 
                     if (!IsPlayerBeingTestedHitByFlashbang()) continue;
-                    _currentPlayerBeingTested.StunTime += (int)(DurationOfFlashbangStunTime * (1 - dist / RangeForFlashbang));
+
+                    _currentPlayerBeingTested.StunTime += (int)(DurationOfFlashbangStunTime * (1 - distanceFromPlayerToFlashbang / RangeForFlashbang));
                 }
+            }
+
+            private bool IsCurrentPlayerBodyDeadOrNull()
+            {
+                return _currentPlayerBeingTested.User.GetPlayer() == null || _currentPlayerBeingTested.User.GetPlayer().IsDead;
             }
 
             private void DebugPlayersWhoAreBeingHitByFlash()
@@ -540,6 +547,8 @@ namespace SFDScripts
                     ClosestHitOnly = false,
                     // Only hit objects that are hit by projectiles
                     ProjectileHit = RayCastFilterMode.True,
+                    // Only hit objects that absorb projectiles
+                    AbsorbProjectile = RayCastFilterMode.True,
                     // filter to hit only walls and players
                     MaskBits = CategoryBits.Player + CategoryBits.StaticGround,
                     // activate filter


### PR DESCRIPTION
I have fixed this by changing the way flashbang calculates players who are going to be hit using raycasting.

[Gif showing result.](https://i.gyazo.com/f43cd23436184416e40d59e961aefcde.gif)

- It is now easy to debug visually what players are going to be hit by a flashbang: players in green will be hit, objects in red are covering a player from being hit. 
- If a player appears in green, he will 100% be hit by flashbang explosion.
- Now we take into account only walls as covers for flashbang explosions
- If a flashbang is shot at, the flashbang will explode (it didn't before)
- The flashbang still stuns depending on the distance of players
- I refactored most of the code that touched to this function making it more readable with less clutter
- Platforms or other objects (barrels, boxes, items, etc...) don't serve as cover for flashbangs, only static or dynamics concretes, walls, woods, etc.
- Added some variables to the debug section of the script that make it easier to debug